### PR TITLE
v3.4.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "rsync" %}
-{% set version = "3.3.0" %}
+{% set version = "3.4.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   - url: https://www.samba.org/ftp/{{ name }}/src/{{ name }}-{{ version }}.tar.gz
-    sha256: 7399e9a6708c32d678a72a63219e96f23be0be2336e50fd1348498d07041df90
+    sha256: 2924bcb3a1ed8b551fc101f740b9f0fe0a202b115027647cf69850d65fd88c52
 
 build:
   number: 0


### PR DESCRIPTION
rsync v3.4.1

**Destination channel:** defaults

### Links

- [PKG-6764](https://anaconda.atlassian.net/browse/PKG-6764) 
- [Upstream repository](https://git.samba.org/?p=rsync.git)
- [Upstream changelog/diff](https://download.samba.org/pub/rsync/NEWS)

### Explanation of changes:

- Bump version and SHA

### Notes
- Addresses 6 CVEs


[PKG-6764]: https://anaconda.atlassian.net/browse/PKG-6764?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ